### PR TITLE
ci: replace self-hosted runner with github hosted runners to run the build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm install
@@ -28,7 +28,7 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Upload production artifacts
+      - name: Upload built artifacts
         uses: actions/upload-artifact@v4
         with:
           name: built-artifacts
@@ -44,7 +44,7 @@ jobs:
     needs: build
 
     steps:
-      - name: Download production artifacts
+      - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
           name: built-artifacts


### PR DESCRIPTION
This will fully utilize the GitHub resources and save some load on our servers.